### PR TITLE
Add metadata validation in script

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,6 +1,10 @@
 ---
 .travis.yml:
-  script: "\"bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'\""
+  script:
+    - bundle exec rake validate
+    - bundle exec rake lint
+    - bundle exec rake spec SPEC_OPTS='--format documentation'
+    - bundle exec rake metadata
   includes:
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 3.0"

--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -7,3 +7,8 @@ PuppetLint.configuration.fail_on_warnings
 PuppetLint.configuration.send('<%= check %>')
 <% end -%>
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+desc "Lint metadata.json file"
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end


### PR DESCRIPTION
This PR will validate `metadata.json` at the end of the Travis CI check.

It also makes the Travis CI output clearer, and checks all tests (validate, lint, spec & metadata) even if one fails (but the status will be fail if one fails still).