### PR TITLE
Updates to .travis.yml, Gemfile, Rakefile and CONTRIBUTING.md

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -3,26 +3,29 @@
   script: "\"bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'\""
   includes:
   - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7.0" FACTER_GEM_VERSION="~> 1.7.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0"
 Gemfile:
   required:
-  - gem: rake
-  - gem: rspec-puppet
-  - gem: puppetlabs_spec_helper
-  - gem: serverspec
-  - gem: puppet-lint
-  - gem: beaker
-  - gem: beaker-rspec
-  - gem: pry
-  - gem: simplecov
+    ':development, :unit_tests':
+      - gem: rake
+      - gem: rspec-puppet
+      - gem: puppetlabs_spec_helper
+      - gem: puppet-lint
+      - gem: simplecov
+      - gem: puppet_facts
+    ':system_tests':
+      - gem: beaker-rspec
+      - gem: serverspec
 Rakefile:
   default_disabled_lint_checks:
+  - 'relative'
   - 'disable_80chars'
   - 'disable_class_inherits_from_params_class'
-  - 'disable_class_parameter_defaults'
   - 'disable_documentation'
   - 'disable_single_quote_string_with_variables'

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -1,6 +1,6 @@
 ---
 language: ruby
-bundler_args: --without development
+bundler_args: --without system_tests
 script: <%= @configs['script'] %>
 matrix:
   fast_finish: true

--- a/moduleroot/CONTRIBUTING.md
+++ b/moduleroot/CONTRIBUTING.md
@@ -41,11 +41,9 @@ Checklist (and a short version for the impatient)
 
     * Pre-requisites:
 
-      - Sign the [Contributor License Agreement](https://cla.puppetlabs.com/)
-
       - Make sure you have a [GitHub account](https://github.com/join)
 
-      - [Create a ticket](http://projects.puppetlabs.com/projects/modules/issues/new), or [watch the ticket](http://projects.puppetlabs.com/projects/modules/issues) you are patching for.
+      - [Create a ticket](https://tickets.puppetlabs.com/secure/CreateIssue!default.jspa), or [watch the ticket](https://tickets.puppetlabs.com/browse/) you are patching for.
 
     * Preferred method:
 
@@ -94,17 +92,7 @@ The long version
       whitespace or other "whitespace errors".  You can do this by
       running "git diff --check" on your changes before you commit.
 
-  2.  Sign the Contributor License Agreement
-
-      Before we can accept your changes, we do need a signed Puppet
-      Labs Contributor License Agreement (CLA).
-
-      You can access the CLA via the [Contributor License Agreement link](https://cla.puppetlabs.com/)
-
-      If you have any questions about the CLA, please feel free to
-      contact Puppet Labs via email at cla-submissions@puppetlabs.com.
-
-  3.  Sending your patches
+  2.  Sending your patches
 
       To submit your changes via a GitHub pull request, we _highly_
       recommend that you have them on a topic branch, instead of
@@ -124,7 +112,7 @@ The long version
       in order to open a pull request.
 
 
-  4.  Update the related GitHub issue.
+  3.  Update the related GitHub issue.
 
       If there is a GitHub issue associated with the change you
       submitted, then you should update the ticket to include the
@@ -220,13 +208,11 @@ review.
 Additional Resources
 ====================
 
-* [Getting additional help](http://projects.puppetlabs.com/projects/puppet/wiki/Getting_Help)
+* [Getting additional help](http://puppetlabs.com/community/get-help)
 
 * [Writing tests](http://projects.puppetlabs.com/projects/puppet/wiki/Development_Writing_Tests)
 
 * [Patchwork](https://patchwork.puppetlabs.com)
-
-* [Contributor License Agreement](https://projects.puppetlabs.com/contributor_licenses/sign)
 
 * [General GitHub documentation](http://help.github.com/)
 

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -1,13 +1,29 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-group :development, :test do
-<% gems = @configs['required'] + (@configs['optional'] || []) -%>
-<% maxlen = gems.map! {|gem| { 'gem' => gem['gem'], 'version' => gem['version'], 'git' => gem['git'], 'branch' => gem['branch'], 'length' => gem['gem'].length + (("', '".length if gem['version']) || 0) + gem['version'].to_s.length } }.map{|gem| gem['length']}.max -%>
+<% groups = {} -%>
+<% (@configs['required'].keys + ((@configs['optional'] || {}).keys)).uniq.each do |key| -%>
+<%   groups[key] = (@configs['required'][key] || []) + ((@configs['optional'] || {})[key] || []) -%>
+<% end -%>
+<% -%>
+<% groups.each do |group, gems| -%>
+group <%= group %> do
+<% maxlen = gems.map! do |gem| -%>
+<%            { -%>
+<%              'gem'     => gem['gem'], -%>
+<%              'version' => gem['version'], -%>
+<%              'git'     => gem['git'], -%>
+<%              'branch'  => gem['branch'], -%>
+<%              'length'  => gem['gem'].length + (("', '".length if gem['version']) || 0) + gem['version'].to_s.length -%>
+<%            } -%>
+<%          end.map do |gem| -%>
+<%            gem['length'] -%>
+<%          end.max -%>
 <% gems.each do |gem| -%>
   gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %>, <%= ' ' * (maxlen - gem['length']) %> :require => false<%= ", :git => '#{gem['git']}'" if gem['git'] %><%= ", :branch => '#{gem['branch']}'" if gem['branch'] %>
 <% end -%>
 end
 
+<% end -%>
 if facterversion = ENV['FACTER_GEM_VERSION']
   gem 'facter', facterversion, :require => false
 else


### PR DESCRIPTION
This commit does the following:
- Reverts removing Puppet 2.7.0 from the travis testing matrix
- Adds the ability for the Gemfile template to parse groups and makes
  the template more human readable
- Breaks the Gemfile configs into unit test and system test groups and
  updates travis to not install system test gems
- Added 'relative' and removed 'disable_clas_parameter_defaults' from
  linter checks
- Updates CONTRIBUTING.md with correct URLS

Running modulesync with --noop produces this diff: https://gist.github.com/cmurphy/943b35e4c7831609bcd9
