### PR TITLE
Add json gem to default gems

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -19,6 +19,7 @@ Gemfile:
       - gem: puppet-lint
       - gem: simplecov
       - gem: puppet_facts
+      - gem: json
     ':system_tests':
       - gem: beaker-rspec
       - gem: serverspec


### PR DESCRIPTION
The puppet_facts gem has a non-explicit dependency on the json gem. On
Ruby 1.8.7 with Puppet 2.7, json is not included by default and there
is no hiera gem to explicitly include it, so we'll add it to our
Gemfile.
