### PR TITLE
Remove extra future parser and old puppet version tests

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -2,18 +2,12 @@
 .travis.yml:
   script: "\"bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'\""
   includes:
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.4.0"
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 2.1.5
-    env: PUPPET_GEM_VERSION="~> 3.4.0"
   - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
 Gemfile:


### PR DESCRIPTION
No reason to test future parser on more than one ruby version. We don't *really* care about puppet 3.4.x...