### PR TITLE
Add puppet 4

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -10,6 +10,12 @@
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+  - rvm: 2.1.6
+    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
+  matrix:
+    allow_failures:
+      - rvm: 2.1.6
+        env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
 Gemfile:
   required:
     ':development, :unit_tests':


### PR DESCRIPTION
Puppet 4 shipped with ruby 2.1.6 in puppet-agent 1.0.1, so we should
test with that.

Not a failing test yet.