### PR TITLE
(MODULES-2207) bin beaker-rspec to ~> 5.1

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -16,7 +16,7 @@ Gemfile:
     ':development':
       - gem: rake
       - gem: rspec
-        version: '~>2.14.1'
+        version: '~>3.0.0'
       - gem: puppet-lint
       - gem: puppetlabs_spec_helper
       - gem: puppet_facts

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -47,11 +47,7 @@ group <%= group %> do
 <%          end.max -%>
 <% gems.each do |gem| -%>
 <% if gem['gem'] == 'beaker-rspec' -%>
-  if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
-    gem 'beaker-rspec', *location_for(beaker_rspec_version)
-  else
-    gem 'beaker-rspec',  :require => false
-  end
+  gem 'beaker-rspec', *location_for(ENV['BEAKER_RSPEC_VERSION'] || '~> 5.1')
 <% elsif gem['gem'] == 'beaker' -%>
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.18')
 <% else -%>


### PR DESCRIPTION
Ensure that beaker rspec is at least on a version that supports the
use of specinfra, and is not known to contain bugs.