### PR TITLE
(maint) several fixes to the default config

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,6 +1,6 @@
 ---
 .travis.yml:
-  script: "\"bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'\""
+  script: "\"bundle exec rake validate lint spec SPEC_OPTS='--format documentation'\""
   includes:
   - rvm: 1.8.7
     env: PUPPET_GEM_VERSION="~> 3.0"
@@ -12,9 +12,6 @@
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 2.1.6
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
-  allow_failures:
-    - rvm: 2.1.6
-      env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
 Gemfile:
   required:
     ':development, :unit_tests':
@@ -24,6 +21,7 @@ Gemfile:
       - gem: simplecov
       - gem: puppet_facts
       - gem: json
+      - gem: metadata-json-lint
     ':system_tests':
       - gem: beaker-rspec
       - gem: serverspec


### PR DESCRIPTION
* run rake once with all the targets instead of spawning it thrice
* enforce unit test on puppet 4
* add the metadata-json-lint gem to enable this validation