### PR TITLE
(maint) reactivate default rspec options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ config_defaults.yml might look like:
 You can add additional environments for a specific module to test by adding an
 extras: section with the same format to the module's .sync.yml.
 
-**`moduleroot/spec/spec.opts`**
+**`moduleroot/.rspec`**
 
-Flat file containing some default rspec options.
+Flat file containing recommended default rspec options.
 
 **`moduleroot/spec/spec_helper.rb`**
 

--- a/moduleroot/.rspec
+++ b/moduleroot/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/moduleroot/spec/spec.opts
+++ b/moduleroot/spec/spec.opts
@@ -1,6 +1,0 @@
---format
-s
---colour
---loadby
-mtime
---backtrace


### PR DESCRIPTION
These can still be overridden by setting SPEC_OPTS or on the commandline,
if required.

This supersedes #17 .