### PR TITLE
(FM-3923) Add puppetlabs-motd module to modulesync

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -26,6 +26,7 @@ Gemfile:
       - gem: beaker-rspec
       - gem: serverspec
       - gem: beaker-puppet_install_helper
+      - gem: master_manipulator
 Rakefile:
   default_disabled_lint_checks:
   - 'relative'

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -16,3 +16,4 @@
 - puppetlabs-tagmail
 - puppetlabs-tomcat
 - puppetlabs-vcsrepo
+- puppetlabs-motd


### PR DESCRIPTION
Prior to this PR:
motd module is not on the list of managed modules in managed_modules.yml 
gem master_manipulator is not in the list of gem in config_defaults.yml

This PR will add motd module into managed list of modulesync and add master_manipulator gem into system_tests group. 

master_manipulator has been heavily used  for master/agent sync tests. It should be in Gemfile of each module that needs integration test.