### PR TITLE
(maint) Use blacksmith for promotions

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -22,6 +22,7 @@ Gemfile:
       - gem: puppet_facts
       - gem: json
       - gem: metadata-json-lint
+      - gem: puppet-blacksmith
     ':system_tests':
       - gem: beaker-rspec
       - gem: serverspec

--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -1,5 +1,6 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
+require 'puppet_blacksmith/rake_tasks'
 
 PuppetLint.configuration.fail_on_warnings = true
 <% checks = @configs['default_disabled_lint_checks'] + ( @configs['extra_disabled_lint_checks'] || [] ) -%>


### PR DESCRIPTION
This updates modules to pull in puppet-blacksmith. This PR opens up modules to utilize the automation submitted in https://github.com/puppet-community/puppet-blacksmith/pull/26 which is a step in deprecating https://github.com/puppetlabs/qe-module-ci-helpers.