### PR TITLE
(maint) Use beaker-hostgenerator to create nodesets

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -32,7 +32,7 @@ Gemfile:
       - gem: beaker-puppet_install_helper
       - gem: master_manipulator
       - gem: beaker-hostgenerator
-        version: '*location_for(ENV["BEAKER_VERSION"])'
+        version: '*location_for(ENV["BEAKER_HOSTGENERATOR_VERSION"])'
 Rakefile:
   default_disabled_lint_checks:
   - 'relative'

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -24,15 +24,16 @@ Gemfile:
       - gem: simplecov
     ':system_tests':
       - gem: beaker-rspec
-      # newer version required to avoid BKR-537
+        from_env: 'BEAKER_RSPEC_VERSION'
+        # newer version required to avoid BKR-537
         version: '>= 3.4'
       - gem: beaker
-        version: '*location_for(ENV["BEAKER_VERSION"])'
+        from_env: 'BEAKER_VERSION'
       - gem: serverspec
       - gem: beaker-puppet_install_helper
       - gem: master_manipulator
       - gem: beaker-hostgenerator
-        version: '*location_for(ENV["BEAKER_HOSTGENERATOR_VERSION"])'
+        from_env: 'BEAKER_HOSTGENERATOR_VERSION'
 Rakefile:
   default_disabled_lint_checks:
   - 'relative'

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -23,12 +23,16 @@ Gemfile:
         version: '>= 2.3.2'
       - gem: simplecov
     ':system_tests':
-      - gem: beaker-puppet_install_helper
-      # newer version required to avoid BKR-537
       - gem: beaker-rspec
+      # newer version required to avoid BKR-537
         version: '>= 3.4'
-      - gem: master_manipulator
+      - gem: beaker
+        version: '*location_for(ENV["BEAKER_VERSION"])'
       - gem: serverspec
+      - gem: beaker-puppet_install_helper
+      - gem: master_manipulator
+      - gem: beaker-hostgenerator
+        version: '*location_for(ENV["BEAKER_VERSION"])'
 Rakefile:
   default_disabled_lint_checks:
   - 'relative'

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -38,6 +38,8 @@ group <%= group %> do
   else
     gem 'beaker-rspec',  :require => false
   end
+
+  gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
 <% else -%>
   gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %>, <%= ' ' * (maxlen - gem['length']) %> :require => false<%= ", :git => '#{gem['git']}'" if gem['git'] %><%= ", :branch => '#{gem['branch']}'" if gem['branch'] %>
 <% end -%>

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -1,12 +1,14 @@
+# vim:ft=ruby
+
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-def location_for(place, fake_version = nil)
+def location_for(place, version = nil)
   if place =~ /^(git[:@][^#]*)#(.*)/
-    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
+    [fake_version, { :git => $1, :branch => $2, :require => false}].compact
   elsif place =~ /^file:\/\/(.*)/
-    ['>= 0', { :path => File.expand_path($1), :require => false }]
+    ['>= 0', { :path => File.expand_path($1), :require => false}]
   else
-    [place, { :require => false }]
+    [place, version, { :require => false}].compact
   end
 end
 
@@ -20,7 +22,7 @@ group <%= group %> do
 <% maxlen = gems.map! do |gem| -%>
 <%            { -%>
 <%              'gem'     => gem['gem'], -%>
-<%              'version' => gem['version'], -%>
+<%              'version' => gem['version'].to_s =~ /(^$)|(location_for)/ ? gem['version'] : "'#{gem['version']}'", -%>
 <%              'git'     => gem['git'], -%>
 <%              'branch'  => gem['branch'], -%>
 <%              'length'  => gem['gem'].length + (("', '".length if gem['version']) || 0) + gem['version'].to_s.length -%>
@@ -29,34 +31,12 @@ group <%= group %> do
 <%            gem['length'] -%>
 <%          end.max -%>
 <% gems.each do |gem| -%>
-<% if gem['gem'] == 'beaker-rspec' -%>
-  if beaker_version = ENV['BEAKER_VERSION']
-    gem 'beaker', *location_for(beaker_version)
-  end
-  if beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION']
-    gem 'beaker-rspec', *location_for(beaker_rspec_version)
-  else
-    gem 'beaker-rspec',  :require => false
-  end
-
-  gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || "~> 0.2")
-<% else -%>
-  gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %>, <%= ' ' * (maxlen - gem['length']) %> :require => false<%= ", :git => '#{gem['git']}'" if gem['git'] %><%= ", :branch => '#{gem['branch']}'" if gem['branch'] %>
-<% end -%>
+  gem '<%= gem['gem'] %>'<%= ", #{gem['version']}" if gem['version'] %><%= gem['version'].to_s =~ /location_for/ ? '' : (', ' + (' ' * (maxlen - gem['length'])) + ' :require => false') %><%= ", :git => '#{gem['git']}'" if gem['git'] %><%= ", :branch => '#{gem['branch']}'" if gem['branch'] %>
 <% end -%>
 end
 <% end -%>
 
-if facterversion = ENV['FACTER_GEM_VERSION']
-  gem 'facter', facterversion, :require => false
-else
-  gem 'facter', :require => false
-end
 
-if puppetversion = ENV['PUPPET_GEM_VERSION']
-  gem 'puppet', puppetversion, :require => false
-else
-  gem 'puppet', :require => false
-end
+gem 'facter', *location_for(ENV['FACTER_GEM_VERSION'])
+gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
 
-# vim:ft=ruby

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -4,7 +4,7 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 def location_for(place, version = nil)
   if place =~ /^(git[:@][^#]*)#(.*)/
-    [fake_version, { :git => $1, :branch => $2, :require => false}].compact
+    [version, { :git => $1, :branch => $2, :require => false}].compact
   elsif place =~ /^file:\/\/(.*)/
     ['>= 0', { :path => File.expand_path($1), :require => false}]
   else
@@ -21,22 +21,30 @@ end
 group <%= group %> do
 <% maxlen = gems.map! do |gem| -%>
 <%            { -%>
-<%              'gem'     => gem['gem'], -%>
-<%              'version' => gem['version'].to_s =~ /(^$)|(location_for)/ ? gem['version'] : "'#{gem['version']}'", -%>
-<%              'git'     => gem['git'], -%>
-<%              'branch'  => gem['branch'], -%>
-<%              'length'  => gem['gem'].length + (("', '".length if gem['version']) || 0) + gem['version'].to_s.length -%>
+<%              'gem'      => gem['gem'], -%>
+<%              'version'  => gem['version'], -%>
+<%              'git'      => gem['git'], -%>
+<%              'branch'   => gem['branch'], -%>
+<%              'from_env' => gem['from_env'], -%>
+<%              'length'   => gem['gem'].length + (("', '".length if gem['version']) || 0) + gem['version'].to_s.length -%>
 <%            } -%>
 <%          end.map do |gem| -%>
 <%            gem['length'] -%>
 <%          end.max -%>
 <% gems.each do |gem| -%>
-  gem '<%= gem['gem'] %>'<%= ", #{gem['version']}" if gem['version'] %><%= gem['version'].to_s =~ /location_for/ ? '' : (', ' + (' ' * (maxlen - gem['length'])) + ' :require => false') %><%= ", :git => '#{gem['git']}'" if gem['git'] %><%= ", :branch => '#{gem['branch']}'" if gem['branch'] %>
+<%   if gem['from_env'] -%>
+  gem '<%= gem['gem'] -%>', <%= ' ' * (maxlen - gem['gem'].length) %> *location_for(ENV['<%= gem['from_env'] -%>']<%= gem['version'] ? " || '#{gem['version']}'" : "" -%>)
+<%   else -%>
+  gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %>, <%= ' ' * (maxlen - gem['length']) %> :require => false<%= ", :git => '#{gem['git']}'" if gem['git'] %><%= ", :branch => '#{gem['branch']}'" if gem['branch'] %>
+<%   end -%>
 <% end -%>
 end
 <% end -%>
 
-
 gem 'facter', *location_for(ENV['FACTER_GEM_VERSION'])
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])
 
+
+if File.exists? "#{__FILE__}.local"
+  eval(File.read("#{__FILE__}.local"), binding)
+end

--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -8,3 +8,27 @@ PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('<%= check %>')
 <% end -%>
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+desc 'Generate pooler nodesets'
+task :gen_nodeset do
+  require 'beaker-hostgenerator'
+  require 'securerandom'
+  require 'fileutils'
+
+  agent_target = ENV['TEST_TARGET']
+  if agent_target
+    master_target = ENV['MASTER_TEST_TARGET'] || 'redhat7-64mdcl'
+    targets = "#{master_target}-#{agent_target}"
+    cli = BeakerHostGenerator::CLI.new([targets])
+    nodeset_dir = "tmp/nodesets"
+    nodeset = "#{nodeset_dir}/#{targets}-#{SecureRandom.uuid}.yaml"
+    FileUtils.mkdir_p(nodeset_dir)
+    File.open(nodeset, 'w') do |fh|
+      fh.print(cli.execute)
+    end
+    puts nodeset
+  else
+    puts "Please set the TEST_TARGET environment variable to use this task"
+    exit 1
+  end
+end

--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -16,19 +16,26 @@ task :gen_nodeset do
   require 'fileutils'
 
   agent_target = ENV['TEST_TARGET']
-  if agent_target
-    master_target = ENV['MASTER_TEST_TARGET'] || 'redhat7-64mdcl'
-    targets = "#{master_target}-#{agent_target}"
-    cli = BeakerHostGenerator::CLI.new([targets])
-    nodeset_dir = "tmp/nodesets"
-    nodeset = "#{nodeset_dir}/#{targets}-#{SecureRandom.uuid}.yaml"
-    FileUtils.mkdir_p(nodeset_dir)
-    File.open(nodeset, 'w') do |fh|
-      fh.print(cli.execute)
-    end
-    puts nodeset
-  else
-    puts "Please set the TEST_TARGET environment variable to use this task"
-    exit 1
+  if ! agent_target
+    STDERR.puts 'TEST_TARGET environment variable is not set'
+    STDERR.puts 'setting to default value of "redhat-64default."'
+    agent_target = 'redhat-64default.'
   end
+
+  master_target = ENV['MASTER_TEST_TARGET']
+  if ! master_target
+    STDERR.puts 'MASTER_TEST_TARGET environment variable is not set'
+    STDERR.puts 'setting to default value of "redhat7-64mdcl"'
+    master_target = 'redhat7-64mdcl'
+  end
+
+  targets = "#{master_target}-#{agent_target}"
+  cli = BeakerHostGenerator::CLI.new([targets])
+  nodeset_dir = "tmp/nodesets"
+  nodeset = "#{nodeset_dir}/#{targets}-#{SecureRandom.uuid}.yaml"
+  FileUtils.mkdir_p(nodeset_dir)
+  File.open(nodeset, 'w') do |fh|
+    fh.print(cli.execute)
+  end
+  puts nodeset
 end


### PR DESCRIPTION
This pulls in beaker-hostgenerator and adds a new rake task
`gen_nodeset` for utilizing it. The output of the rake task on success
is the location of the generated nodeset for use when calling Beaker
later on.

Example workflow:
```
export BEAKER_nodeset=`bundle exec rake gen_nodeset`
bundle exec rake beaker
```