### PR TITLE
(maint) Modify AppVeyor skip commit message

### DIFF
--- a/moduleroot/appveyor.yml
+++ b/moduleroot/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.1.x.{build}
 skip_commits:
-  message: /(^\(?doc\)?.*|.*[A|a]cceptance [T|t]est.*)/
+  message: /(^\(?doc\)?.*/
 clone_depth: 10
 init:
 - SET


### PR DESCRIPTION
The current regular expression will skip any commit message that
contains the phrase Acceptance Test.  This can cause AppVeyor to skip
commits that are updating an acceptance test which is not a desired
behaviour.  Instead contributors should use the [skip ci] text to
skip AppVeyor builds.  This commit changes the regular expression to
only skip (doc) related commits.