### PR TITLE
(maint) Fix typo in appveyor regex

### DIFF
--- a/moduleroot/appveyor.yml
+++ b/moduleroot/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.1.x.{build}
 skip_commits:
-  message: /(^\(?doc\)?.*/
+  message: /^\(?doc\)?.*/
 clone_depth: 10
 init:
 - SET


### PR DESCRIPTION
This commit removes a typo in the skip commit regular expression.  It had an
opening bracket which is not required.