### PR TITLE
(MODULES-3200) Set Hiera and Facter versions for older puppet gems

### DIFF
--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -96,6 +96,17 @@ if puppet_gem_location != :gem || puppetversion < '3.5.0'
   if Gem::Platform.local.os == 'mingw32'
     explicitly_require_windows_gems = true
   end
+
+  if puppet_gem_location == :gem
+    # If facterversion hasn't been specified and we are
+    # looking for a Puppet Gem version less than 3.5.0, we
+    # need to ensure we get a good Facter for specs.
+    gem "facter",">= 1.6.11","<= 1.7.5",:require => false unless facterversion
+    # If hieraversion hasn't been specified and we are
+    # looking for a Puppet Gem version less than 3.5.0, we
+    # need to ensure we get a good Hiera for specs.
+    gem "hiera",">= 1.0.0","<= 1.3.0",:require => false unless hieraversion
+  end
 end
 
 if explicitly_require_windows_gems
@@ -108,10 +119,6 @@ if explicitly_require_windows_gems
     gem "win32-security", "~> 0.1.2",   :require => false
     gem "win32-service", "0.7.2",       :require => false
     gem "minitar", "0.5.4",             :require => false
-    # If facterversion hasn't been specified and we are
-    # looking for a Puppet Gem version less than 3.5.0, we
-    # need to ensure we get a good Facter for Windows specs.
-    gem "facter",">= 1.6.11","<= 1.7.5",:require => false unless facterversion
   else
     gem "ffi", "~> 1.9.0",              :require => false
     gem "win32-eventlog", "~> 0.5",     :require => false


### PR DESCRIPTION
Similar to Facter for Puppet versions less than 3.5.0,
if Hiera version hasn't been set, use a version that
was released with older Puppet versions.

Additionally ensure that both facter and hiera are
treated this way no matter if Puppet is on Windows
or on *nix.