### PR TITLE
(FM-5165) Add MAINTAINERS.md file to all modules

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -41,6 +41,9 @@ appveyor.yml:
       RUBY_VER: 21-x64
   test_script:
   - "bundle exec rake spec SPEC_OPTS='--format documentation'"
+MAINTAINERS.md:
+  maintainers:
+    - "Puppet Forge Modules Team `forge-modules |at| puppet |dot| com`"
 Rakefile:
   default_disabled_lint_checks:
   - 'relative'

--- a/moduleroot/MAINTAINERS.md
+++ b/moduleroot/MAINTAINERS.md
@@ -1,0 +1,10 @@
+## Maintenance
+
+<% if @configs['maintainers'] -%>
+Maintainers:
+<%   @configs['maintainers'].each do |name| -%>
+  - <%= name %>
+<%   end -%>
+<% end -%>
+
+Tickets: https://tickets.puppet.com/browse/MODULES. Make sure to set component to `<%= @configs[:puppet_module].gsub('puppetlabs-','') -%>`.


### PR DESCRIPTION
All Puppet projects should contain a Maintenance section as either inside
README or in a separate file called MAINTAINERS.md.  This commit adds the
default modsync to create a MAINTAINERS.md file.  A file was used instead
of updating README as it is much easier to managae and automate the entire
content of the file instead of a section within a README, which is unique per
module.

The default of the Forge Modules mailing address is used, but can be modified
on a per module basis.

Example file from ACL module;
``` markdown
## Maintenance

Maintainers:
  - Puppet Forge Modules Team `forge-modules |at| puppet |dot| com`

Tickets: https://tickets.puppet.com/browse/MODULES. Make sure to set component to `acl`.
```