### PR TITLE
(FM-5165) Add MAINTAINERS.md file to all modules

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -56,3 +56,7 @@ Rakefile:
   - 'disable_class_inherits_from_params_class'
   - 'disable_documentation'
   - 'disable_single_quote_string_with_variables'
+MAINTAINERS.md:
+  maintainers:
+    - "Puppet Forge Modules Team `forge-modules |at| puppet |dot| com`"
+    

--- a/moduleroot/MAINTAINERS.md
+++ b/moduleroot/MAINTAINERS.md
@@ -1,0 +1,10 @@
+## Maintenance
+
+<% if @configs['maintainers'] -%>
+Maintainers:
+<%   @configs['maintainers'].each do |name| -%>
+  - <%= name %>
+<%   end -%>
+<% end -%>
+
+Tickets: https://tickets.puppet.com/browse/MODULES. Make sure to set component to `<%= @configs[:puppet_module].gsub('puppetlabs-','') -%>`.


### PR DESCRIPTION
All Puppet projects should contain a Maintenance section as either inside
README or in a separate file called MAINTAINERS.md.  This commit adds the
default modsync to create a MAINTAINERS.md file.  A file was used instead
of updating README as it is much easier to managae and automate the entire
content of the file instead of a section within a README, which is unique per
module.

The default of the Forge Modules mailing address is used, but can be modified
on a per module basis.