### PR TITLE
(maint) Update modsync root files after audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 *.iml
 .*.sw[op]
 .DS_Store
+Gemfile.local

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -41,9 +41,15 @@ appveyor.yml:
       RUBY_VER: 21-x64
   test_script:
   - "bundle exec rake spec SPEC_OPTS='--format documentation'"
+
+LICENSE:
+  license_type: 'apache2' # Available options 'puppetpe' and 'apache2' (default is apache2)
+
 MAINTAINERS.md:
   maintainers:
     - "Puppet Forge Modules Team `forge-modules |at| puppet |dot| com`"
+
+# Apache 2 NOTICE file generation.  Please mark unmanaged:true if using puppetpe license type
 NOTICE:
   copyright_holders:
     - name: 'Puppet, Inc.'
@@ -51,6 +57,7 @@ NOTICE:
     # - name: '<name of holder>' (required)
     #   begin: <year or 'latest'> (optional) (latest is the year when modsync is run)
     #   end:   <year or 'latest'> (optional) (latest is the year when modsync is run)    
+
 Rakefile:
   default_disabled_lint_checks:
   - 'relative'

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -16,5 +16,12 @@ matrix:
     env: <%= extra['env'] %>
 <%   end -%>
 <% end -%>
+<% if @configs['allow_failures'] -%>
+<%   @configs['allow_failures'].each do |failure| -%>
+  allow_failures:
+  - rvm: <%= failure['rvm'] %>
+    env: <%= failure['env'] %>
+<%   end -%>
+<% end -%>
 notifications:
   email: false

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -46,13 +46,14 @@ end
 group <%= group %> do
 <% maxlen = gems.map! do |gem| -%>
 <%            { -%>
-<%              'gem'     => gem['gem'], -%>
-<%              'version' => gem['version'], -%>
-<%              'git'     => gem['git'], -%>
-<%              'branch'  => gem['branch'], -%>
-<%              'platforms'  => gem['platforms'], -%>
-<%              'length'  => gem['gem'].length + (("', '".length if gem['version']) || 0) + gem['version'].to_s.length, -%>
-<%              'condition'      => gem['condition'] -%>
+<%              'gem'       => gem['gem'], -%>
+<%              'version'   => gem['version'], -%>
+<%              'git'       => gem['git'], -%>
+<%              'branch'    => gem['branch'], -%>
+<%              'ref'       => gem['ref'], -%>
+<%              'platforms' => gem['platforms'], -%>
+<%              'length'    => gem['gem'].length + (("', '".length if gem['version']) || 0) + gem['version'].to_s.length, -%>
+<%              'condition' => gem['condition'] -%>
 <%            } -%>
 <%          end.map do |gem| -%>
 <%            gem['length'] -%>
@@ -63,7 +64,7 @@ group <%= group %> do
 <% elsif gem['gem'] == 'beaker' -%>
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.20')
 <% else -%>
-  gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %>, <%= ' ' * (maxlen - gem['length']) %> :require => false<%= ", :git => '#{gem['git']}'" if gem['git'] %><%= ", :branch => '#{gem['branch']}'" if gem['branch'] %><%= ", :platforms => #{gem['platforms']}" if gem['platforms'] %><%= " if #{gem['condition']}" if gem['condition'] %>
+  gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %>, <%= ' ' * (maxlen - gem['length']) %> :require => false<%= ", :git => '#{gem['git']}'" if gem['git'] %><%= ", :branch => '#{gem['branch']}'" if gem['branch'] %><%= ", :ref => '#{gem['ref']}'" if gem['ref'] %><%= ", :platforms => #{gem['platforms']}" if gem['platforms'] %><%= " if #{gem['condition']}" if gem['condition'] %>
 <% end -%>
 <% end -%>
 end

--- a/moduleroot/LICENSE
+++ b/moduleroot/LICENSE
@@ -1,3 +1,15 @@
+<%
+# Determine the license types
+lictype = 'apache2'
+if @configs['license_type']
+  case @configs['license_type']
+  when 'puppetpe'
+    lictype = 'puppetpe'
+  end
+end
+
+# Default Apache 2 License
+if lictype == 'apache2' -%>
 
                                  Apache License
                            Version 2.0, January 2004
@@ -199,4 +211,16 @@
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
-   limitations under the License.
+   limitations under the License.<%
+end
+
+# Puppet PE Only License
+if lictype == 'puppetpe' -%>
+This Module is only available for users of Puppet Enterprise with a valid Software License Agreement 
+for Puppet Enterprise.  This Module is not available for users of Puppet software under an open source license.
+
+By downloading this Module, you agree that you have a valid Software License Agreement with Puppet for 
+Puppet Enterprise and you further agree that your use of this Module is governed by the terms of that 
+Software License Agreement.
+<%
+end -%>


### PR DESCRIPTION
The modsync moduleroot files required modification as they did not provide
the required configuration parameters for Windows modules.

- Added the ability for Apache2 and Puppet PE licensing per module.  Apache 2
  is the default if not specified
- Added 'allow_failures' to Travis CI config.  This is a BAD practice and
  should not be used, however it can be used temporarily to allow PR CIs to
  continue if needs be
- Added the ability to specify a 'ref' for a git based gem in the Gemfile

Housekeeping
- Added gemfile.local to gitignore