### PR TITLE
(maint) Update CONTRIBUTING.md and gitignore

### DIFF
--- a/moduleroot/.gitignore
+++ b/moduleroot/.gitignore
@@ -13,6 +13,7 @@ coverage/
 .*.sw[op]
 .DS_Store
 .rspec
+tmp/
 
 <% if ! @configs['paths'].nil? -%>
 <% @configs['paths'].each do |path| -%>

--- a/moduleroot/CONTRIBUTING.md
+++ b/moduleroot/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Checklist (and a short version for the impatient)
 
       - Make sure you have a [GitHub account](https://github.com/join)
 
-      - [Create a ticket](https://tickets.puppetlabs.com/secure/CreateIssue!default.jspa), or [watch the ticket](https://tickets.puppetlabs.com/browse/) you are patching for.
+      - [Create a ticket](https://tickets.puppet.com/secure/CreateIssue!default.jspa), or [watch the ticket](https://tickets.puppet.com/browse/) you are patching for.
 
     * Preferred method:
 


### PR DESCRIPTION
Added the directory tmp to the gitigore list.  It seems to have been
missing in error.  The CONTRIBUTING.MD file was updated by changing
puppetlabs to puppet after the company change.