### PR TITLE
(FM-5240) Set maximum version on win32-xxx gems

### DIFF
--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -114,22 +114,22 @@ if explicitly_require_windows_gems
   # This also means Puppet Gem less than 3.5.0 - this has been tested back
   # to 3.0.0. Any further back is likely not supported.
   if puppet_gem_location == :gem
-    gem "ffi", "1.9.0",                 :require => false
-    gem "win32-eventlog", "0.5.3",      :require => false
-    gem "win32-process", "0.6.5",       :require => false
-    gem "win32-security", "~> 0.1.2",   :require => false
-    gem "win32-service", "0.7.2",       :require => false
-    gem "minitar", "0.5.4",             :require => false
+    gem "ffi", "1.9.0",                          :require => false
+    gem "win32-eventlog", "0.5.3","<= 0.6.5",    :require => false
+    gem "win32-process", "0.6.5","<= 0.7.5",     :require => false
+    gem "win32-security", "~> 0.1.2","<= 0.2.5", :require => false
+    gem "win32-service", "0.7.2","<= 0.8.7",     :require => false
+    gem "minitar", "0.5.4",                      :require => false
   else
-    gem "ffi", "~> 1.9.0",              :require => false
-    gem "win32-eventlog", "~> 0.5",     :require => false
-    gem "win32-process", "~> 0.6",      :require => false
-    gem "win32-security", "~> 0.1",     :require => false
-    gem "win32-service", "~> 0.7",      :require => false
-    gem "minitar", "~> 0.5.4",          :require => false
+    gem "ffi", "~> 1.9.0",                       :require => false
+    gem "win32-eventlog", "~> 0.5","<= 0.6.5",   :require => false
+    gem "win32-process", "~> 0.6","<= 0.7.5",    :require => false
+    gem "win32-security", "~> 0.1","<= 0.2.5",   :require => false
+    gem "win32-service", "~> 0.7","<= 0.8.7",    :require => false
+    gem "minitar", "~> 0.5.4",                   :require => false
   end
 
-  gem "win32-dir", "~> 0.3",            :require => false
+  gem "win32-dir", "~> 0.3","<= 0.4.9", :require => false
   gem "win32console", "1.3.2",          :require => false if RUBY_VERSION =~ /^1\./
 
   # Puppet less than 3.7.0 requires these.
@@ -144,6 +144,16 @@ if explicitly_require_windows_gems
   gem "win32-taskscheduler", "0.2.2",   :require => false
   gem "windows-api", "0.4.3",           :require => false
   gem "windows-pr",  "1.2.3",           :require => false
+else
+  if Gem::Platform.local.os == 'mingw32'
+    # If we're using a Puppet gem on windows, which handles its own win32-xxx gem dependencies (Pup 3.5.0 and above), set maximum versions
+    # Required due to PUP-6445
+    gem "win32-dir", "<= 0.4.9",        :require => false
+    gem "win32-eventlog", "<= 0.6.5",   :require => false
+    gem "win32-process", "<= 0.7.5",    :require => false
+    gem "win32-security", "<= 0.2.5",   :require => false
+    gem "win32-service", "<= 0.8.7",    :require => false
+  end
 end
 <% end -%>
 


### PR DESCRIPTION
The Win32-Service gem was updated to 0.8.9 however the new gem pulled in a
dependant gem called ffi-win32-extensions which has a name collision on the
FFI:Pointer.read_wide_string method.  This causes Puppet to fail in mutiple
locations.

This commit sets the maximum version of the win32-xxxx gems the same as puppet
does in https://github.com/puppetlabs/puppet/master/ext/project_data.yaml#L49-L54