### PR TITLE
(maint) Disable 140char lint check.

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -52,7 +52,7 @@ Gemfile:
 Rakefile:
   default_disabled_lint_checks:
   - 'relative'
-  - 'disable_char_check'
+  - 'disable_140chars'
   - 'disable_class_inherits_from_params_class'
   - 'disable_documentation'
   - 'disable_single_quote_string_with_variables'


### PR DESCRIPTION
Changing the config option back to 140 char, because the disable_char_check one doesn't exist and was a flaw in the docs.

/cc @tphoney 