### PR TITLE
(PUP-6473) Pin FFI to 1.9.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 ---
 sudo: false
 language: ruby
+rvm:
+  - 2.2
 cache: bundler
 # Run msync but in noop (Test Command).  Also, do not update the sqlserver module (regex escaped for bash and then escaped for yaml)
 script: "bundle exec msync update --noop --git-base=https://github.com/ -f \\^\\(\\(\\?\\!-sqlserver\\).\\)\\*\\$"

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -114,14 +114,18 @@ if explicitly_require_windows_gems
   # This also means Puppet Gem less than 3.5.0 - this has been tested back
   # to 3.0.0. Any further back is likely not supported.
   if puppet_gem_location == :gem
-    gem "ffi", "1.9.0",                          :require => false
+    # ffi is pinned due to PUP-6473.
+    # Can be removed once https://github.com/ffi/ffi/issues/506 is resolved  
+    gem "ffi", "1.9.0", "<= 1.9.10",             :require => false
     gem "win32-eventlog", "0.5.3","<= 0.6.5",    :require => false
     gem "win32-process", "0.6.5","<= 0.7.5",     :require => false
     gem "win32-security", "~> 0.1.2","<= 0.2.5", :require => false
     gem "win32-service", "0.7.2","<= 0.8.7",     :require => false
     gem "minitar", "0.5.4",                      :require => false
   else
-    gem "ffi", "~> 1.9.0",                       :require => false
+    # ffi is pinned due to PUP-6473.
+    # Can be removed once https://github.com/ffi/ffi/issues/506 is resolved  
+    gem "ffi", "~> 1.9.0", "<= 1.9.10",          :require => false
     gem "win32-eventlog", "~> 0.5","<= 0.6.5",   :require => false
     gem "win32-process", "~> 0.6","<= 0.7.5",    :require => false
     gem "win32-security", "~> 0.1","<= 0.2.5",   :require => false
@@ -147,6 +151,9 @@ if explicitly_require_windows_gems
 else
   if Gem::Platform.local.os == 'mingw32'
     # If we're using a Puppet gem on windows, which handles its own win32-xxx gem dependencies (Pup 3.5.0 and above), set maximum versions
+    # ffi is pinned due to PUP-6473.
+    # Can be removed once https://github.com/ffi/ffi/issues/506 is resolved  
+    gem "ffi", "~> 1.9.6", "<= 1.9.10", :require => false
     # Required due to PUP-6445
     gem "win32-dir", "<= 0.4.9",        :require => false
     gem "win32-eventlog", "<= 0.6.5",   :require => false


### PR DESCRIPTION
An update to FFI (1.9.11) has caused downstream gems to error due to a bug
introduced in 1.9.11.  FFI Github issue 506 (ffi/ffi#506)
shows this is affecting other users of FFI as well.  This commit pins FFI to the
latest known good working version of 1.9.10.  This change will be reverted in the
future once issue 506 is resolved.