### PR TITLE
(PUP-6477) Revert changes made in PUP-6473

### DIFF
--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -153,7 +153,7 @@ else
     # If we're using a Puppet gem on windows, which handles its own win32-xxx gem dependencies (Pup 3.5.0 and above), set maximum versions
     # ffi is pinned due to PUP-6473.
     # Can be removed once https://github.com/ffi/ffi/issues/506 is resolved  
-    gem "ffi", "<= 1.9.10",             :require => false
+    gem "ffi", "~> 1.9.6", "<= 1.9.10", :require => false
     # Required due to PUP-6445
     gem "win32-dir", "<= 0.4.9",        :require => false
     gem "win32-eventlog", "<= 0.6.5",   :require => false

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -114,18 +114,14 @@ if explicitly_require_windows_gems
   # This also means Puppet Gem less than 3.5.0 - this has been tested back
   # to 3.0.0. Any further back is likely not supported.
   if puppet_gem_location == :gem
-    # ffi is pinned due to PUP-6473.
-    # Can be removed once https://github.com/ffi/ffi/issues/506 is resolved  
-    gem "ffi", "1.9.0", "<= 1.9.10",             :require => false
+    gem "ffi", "1.9.0",                          :require => false
     gem "win32-eventlog", "0.5.3","<= 0.6.5",    :require => false
     gem "win32-process", "0.6.5","<= 0.7.5",     :require => false
     gem "win32-security", "~> 0.1.2","<= 0.2.5", :require => false
     gem "win32-service", "0.7.2","<= 0.8.7",     :require => false
     gem "minitar", "0.5.4",                      :require => false
   else
-    # ffi is pinned due to PUP-6473.
-    # Can be removed once https://github.com/ffi/ffi/issues/506 is resolved  
-    gem "ffi", "~> 1.9.0", "<= 1.9.10",          :require => false
+    gem "ffi", "~> 1.9.0",                       :require => false
     gem "win32-eventlog", "~> 0.5","<= 0.6.5",   :require => false
     gem "win32-process", "~> 0.6","<= 0.7.5",    :require => false
     gem "win32-security", "~> 0.1","<= 0.2.5",   :require => false
@@ -151,9 +147,6 @@ if explicitly_require_windows_gems
 else
   if Gem::Platform.local.os == 'mingw32'
     # If we're using a Puppet gem on windows, which handles its own win32-xxx gem dependencies (Pup 3.5.0 and above), set maximum versions
-    # ffi is pinned due to PUP-6473.
-    # Can be removed once https://github.com/ffi/ffi/issues/506 is resolved  
-    gem "ffi", "~> 1.9.6", "<= 1.9.10", :require => false
     # Required due to PUP-6445
     gem "win32-dir", "<= 0.4.9",        :require => false
     gem "win32-eventlog", "<= 0.6.5",   :require => false


### PR DESCRIPTION
The FFI issue has been resolved and released as 1.9.13

This reverts commit 6ef868e.
This reverts commit 83d2887.