### PR TITLE
Update ruby to 2.1.9

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -13,7 +13,7 @@
     env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=@@SET@@
     script: bundle exec rake beaker
   includes:
-  - rvm: 2.1.6
+  - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
     bundler_args: --without system_tests
   - rvm: 2.1.5


### PR DESCRIPTION
This is the version currently shipped with puppet-agent.

The jobs for 3.0 stay at a ruby (2.1.5) that was around the time 4.0.0 was shipped, and 1.9.3, which is still in widespread use on older distros.