### PR TITLE
(PUP-6459) Update win32-service to 0.8.8

### DIFF
--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -122,14 +122,14 @@ if explicitly_require_windows_gems
     gem "win32-eventlog", "0.5.3","<= 0.6.5",    :require => false
     gem "win32-process", "0.6.5","<= 0.7.5",     :require => false
     gem "win32-security", "~> 0.1.2","<= 0.2.5", :require => false
-    gem "win32-service", "0.7.2","<= 0.8.7",     :require => false
+    gem "win32-service", "0.7.2","<= 0.8.8",     :require => false
     gem "minitar", "0.5.4",                      :require => false
   else
     gem "ffi", "~> 1.9.0",                       :require => false
     gem "win32-eventlog", "~> 0.5","<= 0.6.5",   :require => false
     gem "win32-process", "~> 0.6","<= 0.7.5",    :require => false
     gem "win32-security", "~> 0.1","<= 0.2.5",   :require => false
-    gem "win32-service", "~> 0.7","<= 0.8.7",    :require => false
+    gem "win32-service", "~> 0.7","<= 0.8.8",    :require => false
     gem "minitar", "~> 0.5.4",                   :require => false
   end
 
@@ -156,7 +156,7 @@ else
     gem "win32-eventlog", "<= 0.6.5",   :require => false
     gem "win32-process", "<= 0.7.5",    :require => false
     gem "win32-security", "<= 0.2.5",   :require => false
-    gem "win32-service", "<= 0.8.7",    :require => false
+    gem "win32-service", "<= 0.8.8",    :require => false
   end
 end
 <% end -%>


### PR DESCRIPTION
- Version 0.8.7 of the win32-service gem had a bug that prevented it
   from properly retrieving all services on Windows 10 with the
   Win32::Service.services call.

   In particular, the services pvhdparser and vhdparser don't have
   delayed start info, which would previously cause errors.

   This is fixed in the 0.8.8 version of the gem

- This is required for PUP 4.6.0 and above