### PR TITLE
(MODULES-3775) Add Ruby 2.3 to appveyor and travis

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -8,6 +8,8 @@
     env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 4.0"
+  - rvm: 2.3.1
+    env: PUPPET_GEM_VERSION="~> 4.0"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
 Gemfile:
@@ -39,6 +41,10 @@ appveyor.yml:
       RUBY_VER: 21
     - PUPPET_GEM_VERSION: '~> 4.0'
       RUBY_VER: 21-x64
+    - PUPPET_GEM_VERSION: '~> 4.0'
+      RUBY_VER: 23
+    - PUPPET_GEM_VERSION: '~> 4.0'
+      RUBY_VER: 23-x64
   test_script:
   - "bundle exec rake spec SPEC_OPTS='--format documentation'"
 


### PR DESCRIPTION
This commit adds Ruby 2.3 versions to test against via Travis and AppVeyor, in
anticipation of supporting this ruby version in an upcoming version of Puppet.