### PR TITLE
(maint) Restrict sys-admin gem to Ruby 1.x

### DIFF
--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -136,6 +136,10 @@ if explicitly_require_windows_gems
   gem "win32-dir", "~> 0.3","<= 0.4.9", :require => false
   gem "win32console", "1.3.2",          :require => false if RUBY_VERSION =~ /^1\./
 
+  # sys-admin was removed in Puppet 3.7.0+, and doesn't compile
+  # under Ruby 2.3 - so restrict it to Ruby 1.x
+  gem "sys-admin", "1.5.6",             :require => false if RUBY_VERSION =~ /^1\./
+
   # Puppet less than 3.7.0 requires these.
   # Puppet 3.5.0+ will control the actual requirements.
   # These are listed in formats that work with all versions of
@@ -143,7 +147,6 @@ if explicitly_require_windows_gems
   # We do not want to allow newer versions than what came out after
   # 3.6.x to be used as they constitute some risk in breaking older
   # functionality. So we set these to exact versions.
-  gem "sys-admin", "1.5.6",             :require => false
   gem "win32-api", "1.4.8",             :require => false
   gem "win32-taskscheduler", "0.2.2",   :require => false
   gem "windows-api", "0.4.3",           :require => false


### PR DESCRIPTION
 - Only Puppet 3.6.z and lower requires sys-admin gem, which was removed
   for Puppet 3.7.0+.  Since that version only requires on at most Ruby
   1.9.3, restrict its installation there.

   Otherwise, running from a file:/// source for local Puppet with Ruby
   2.3 on Windows will fail to perform a `bundle install`

 sys-admin was removed officially in:
https://github.com/puppetlabs/puppet/commit/480f0362dde3ad52045ed026bafdc13ac6686174