### PR TITLE
Workaround frozen strings on ruby 1.9

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -26,7 +26,9 @@ Gemfile:
   required:
     ':development':
       - gem: puppet-lint
+      # Only non-windows because it needs json
       - gem: metadata-json-lint
+        platforms: 'ruby'
       - gem: puppet_facts
       # newer version required for ruby 1.9 compat
       - gem: puppet-blacksmith
@@ -37,32 +39,34 @@ Gemfile:
       # newer version required to PUP-5743
       - gem: rspec-puppet
         version: '>= 2.3.2'
+      # Only non-windows because it needs json
       - gem: rspec-puppet-facts
+        platforms: 'ruby'
       # the newly released mocha 1.2.0 causes hangs during spec testing. See MODULES-3958 for a long-term solution
       - gem: mocha
         version: '< 1.2.0'
+      # Only non-windows because it needs json
       - gem: simplecov
+        platforms: 'ruby'
       - gem: parallel_tests
         version: '< 2.10.0'
-        condition: "Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')"
+        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')"
       - gem: parallel_tests
-        condition: "Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')"
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')"
       - gem: rubocop
         version: '0.41.2'
-        condition: "Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')"
+        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')"
       - gem: rubocop
-        condition: "Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')"
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')"
       - gem: rubocop-rspec
         version: '~> 1.6'
-        condition: "Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')"
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
       - gem: pry
       # json_pure 2.0.2 added a requirement on ruby >= 2. We pin to json_pure <= 2.0.1
       # if using ruby 1.x
       - gem: json_pure
         version: '<= 2.0.1'
-        condition: "Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')"
-      - gem: json_pure
-        condition: "Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')"
+        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')"
     ':system_tests':
       - gem: beaker
         from_env: 'BEAKER_VERSION'
@@ -70,14 +74,14 @@ Gemfile:
         condition: "supports_windows"
       - gem: beaker
         from_env: 'BEAKER_VERSION'
-        condition: "Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0') and ! supports_windows"
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0') and ! supports_windows"
       - gem: beaker
         from_env: 'BEAKER_VERSION'
         version: '< 3'
-        condition: "Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.3.0') and ! supports_windows"
+        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0') and ! supports_windows"
       # beaker 3 requires this for PE installs
       - gem: beaker-pe
-        condition: "Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')"
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
       - gem: beaker-rspec
         from_env: 'BEAKER_RSPEC_VERSION'
         # newer version required to avoid BKR-537

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -107,7 +107,7 @@ gem 'hiera', *location_for(ENV['HIERA_GEM_VERSION']) if ENV['HIERA_GEM_VERSION']
 explicitly_require_windows_gems = false
 puppet_gem_location = gem_type(ENV['PUPPET_GEM_VERSION'])
 # This is not a perfect answer to the version check
-if puppet_gem_location != :gem || (Gem::Version.correct?(ENV['PUPPET_GEM_VERSION']) && Gem::Requirement.new('< 3.5.0').satisfied_by?(Gem::Version.new(ENV['PUPPET_GEM_VERSION'])))
+if puppet_gem_location != :gem || (ENV['PUPPET_GEM_VERSION'] && Gem::Version.correct?(ENV['PUPPET_GEM_VERSION']) && Gem::Requirement.new('< 3.5.0').satisfied_by?(Gem::Version.new(ENV['PUPPET_GEM_VERSION'].dup)))
   if Gem::Platform.local.os == 'mingw32'
     explicitly_require_windows_gems = true
   end


### PR DESCRIPTION
As per https://github.com/jonnytdevops/puppetlabs-firewall/commit/c1b0e7b46b8277d41c75e50465908d4cbc3f3267