### PR TITLE
(FM-5800) Update travis to use release_checks

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,6 +1,6 @@
 ---
 .travis.yml:
-  script: "\"bundle exec rake validate lint spec\""
+  script: "\"bundle exec rake release_checks\""
   docker_sets:
   - set: docker/ubuntu-14.04
   - set: docker/centos-7


### PR DESCRIPTION
This finally concludes our quest to automate all of our low-priority release
checks.

It also needs to wait for the PRs referenced in FM-5800 to be merged.