### PR TITLE
add vendor/ to gitignore

### DIFF
--- a/moduleroot/.gitignore
+++ b/moduleroot/.gitignore
@@ -13,6 +13,7 @@ coverage/
 .*.sw[op]
 .DS_Store
 tmp/
+vendor/
 
 <% if ! @configs['paths'].nil? -%>
 <% @configs['paths'].each do |path| -%>


### PR DESCRIPTION
for the Jenkins "release to forge" jorb. 

the blacksmith job that Jenkins runs looks to .gitignore for files to exclude from the module tarball. Since Jenkins also installs all dependencies in vendor/, if it's not in the gitignore it will cause the job to fail because the tarball will be too big