### PR TITLE
[MODULES-4224] Add beaker-module_install_helper to all modules gemfiles

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -114,6 +114,7 @@ Gemfile:
         version: '~> 5.1'
         condition: "supports_windows"
       - gem: beaker-puppet_install_helper
+      - gem: beaker-module_install_helper
       - gem: master_manipulator
       - gem: beaker-hostgenerator
         from_env: 'BEAKER_HOSTGENERATOR_VERSION'


### PR DESCRIPTION
The plan is to onboard every module to use the beaker-module_install_helper library and from there extend its functionality in the future. Therefore I have added it to the Gemfile of all repositories to save doing this individually in the future.