### PR TITLE
(MODULES-4272) Update .gitignore for strings

### DIFF
--- a/moduleroot/.gitignore
+++ b/moduleroot/.gitignore
@@ -10,6 +10,9 @@ coverage/
 log/
 .idea/
 *.iml
+.yardoc
+.yardwarns
+doc/
 <% if ! @configs['paths'].nil? -%>
 <% @configs['paths'].each do |path| -%>
 <%= path %>


### PR DESCRIPTION
As we move towards using strings to document our modules, there
will be files YARD generates that we don't want to commit to the
module repo. Update the default gitignore for modulesync so that
it includes these files.