### PR TITLE
(maint) Add puppetlabs-puppet_agent as a managed module

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -29,6 +29,7 @@
     puppetlabs-mysql:                    [linux]
     puppetlabs-ntp:                      [linux]
     puppetlabs-postgresql:               [linux]
+    puppetlabs-puppet_agent:             [linux,windows]
     puppetlabs-rabbitmq:                 [linux]
     puppetlabs-stdlib:                   [linux]
     puppetlabs-tagmail:                  [linux]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -21,6 +21,7 @@
 - puppetlabs-ntp
 - puppetlabs-postgresql
 - puppetlabs-powershell
+- puppetlabs-puppet_agent
 - puppetlabs-rabbitmq
 - puppetlabs-reboot
 - puppetlabs-registry


### PR DESCRIPTION
This commit adds the puppetlabs-puppet_agent module as a managed module.

This PR builds on https://github.com/puppetlabs/modulesync_configs/pull/128