### PR TITLE
(maint) Fix Travis msync invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ language: ruby
 rvm: 2.3.1
 cache: bundler
 # Run msync but in noop (Test Command).  Also, do not update the sqlserver/vsphere modules (regex escaped for yaml)
-script: 'bundle exec msync update --noop --git-base=https://github.com/ -x "\(sqlserver\|vsphere\)"'
+script: 'bundle exec msync update --noop --git-base=https://github.com/ -x "(sqlserver|vsphere)"'
 notifications:
   email: false


### PR DESCRIPTION
Previously, the Travis CI command used to verify the modsync configurations was
modified to exclue the vsphere and sqlserver modules in commit 3012627.
However the command was escaping text which did not need to be, thus the command
was failing to exclude those modules.  This commit removes the escaping and
ensures that the vsphere and sqlserver module are not checked during a Travis CI
run. These modules are excluded as they are private Github repos.