### PR TITLE
(MODULES-4471) Add yarjuf Gem by default

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -82,6 +82,8 @@ Gemfile:
       # newer version required to PUP-5743
       - gem: rspec-puppet
         version: '>= 2.3.2'
+      - gem: yarjuf
+        version: '~> 2.0'
       # Only non-windows because it needs json
       - gem: rspec-puppet-facts
         platforms: 'ruby'


### PR DESCRIPTION
The yarjuf gem is used to convert rspec reports in JUnit XML files, which will
be used by CI systems to report on test results.