### PR TITLE
(MODULES-4375) add locales directory and config.yaml

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -173,3 +173,10 @@ Rakefile:
 
 spec/spec.opts:
   delete: true
+
+locales/config.yaml:
+  copyright_holder: 'Puppet, Inc.'
+  comments_tag: 'TRANSLATOR'
+  bugs_address: 'docs@puppet.com'
+  default_locale: 'en'
+  source_files: ['metadata.json']

--- a/moduleroot/locales/config.yaml
+++ b/moduleroot/locales/config.yaml
@@ -1,0 +1,27 @@
+---
+# This is the project-specific configuration file for setting up
+# fast_gettext for your project.
+gettext:
+  # This is used for the name of the .pot and .po files; they will be
+  # called <project_name>.pot?
+  project_name: <%= @configs[:puppet_module] %>
+  # This is used in comments in the .pot and .po files to indicate what
+  # project the files belong to and should bea little more desctiptive than
+  # <project_name>
+  package_name: <%= @configs[:puppet_module] %>
+  # The locale that the default messages in the .pot file are in
+  default_locale: <%= @configs['default_locale'] %>
+  # The email used for sending bug reports.
+  bugs_address: <%= @configs['bugs_address'] %>
+  # The holder of the copyright.
+  copyright_holder: <%= @configs['copyright_holder'] %>
+  # This determines which comments in code should be eligible for translation.
+  # Any comments that start with this string will be externalized. (Leave
+  # empty to include all.)
+  comments_tag: <%= @configs['comments_tag'] %>
+  # Patterns for +Dir.glob+ used to find all files that might contain
+  # translatable content, relative to the project root directory
+  source_files:
+  <% @configs['source_files'].each do |glob| -%>
+    - '<%= glob -%>'
+  <% end if @configs['source_files'].size > 0 -%>


### PR DESCRIPTION
All modules now need to have a locales/ directory that contains a config.yaml for i18n tasks and storing translations (pot and po files). This adds the locales directory and the config.yaml inside it as well as the configurable values in config_defaults. At a later point there will also be a directory for translated readmes.