### PR TITLE
[MODULES-4506] Implement puppet-module-gems

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -69,38 +69,16 @@ Gemfile:
   required:
     ':development':
       # Gems built using puppet-module-gems utility
-      - gem: 'puppet-module-posix-default-r2.1'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
+      - gem: 'puppet-module-posix-default-r#{minor_version}'
         platforms: 'ruby'
-      - gem: 'puppet-module-posix-default-r2.3'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
-        platforms: 'ruby'
-      - gem: 'puppet-module-win-default-r2.1'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
+      - gem: 'puppet-module-win-default-r#{minor_version}'
         platforms:
           - 'mswin'
           - 'mingw'
           - 'x64_mingw'
-      - gem: 'puppet-module-win-default-r2.3'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
-        platforms:
-          - 'mswin'
-          - 'mingw'
-          - 'x64_mingw'
-      - gem: 'puppet-module-posix-dev-r2.1'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
+      - gem: 'puppet-module-posix-dev-r#{minor_version}'
         platforms: 'ruby'
-      - gem: 'puppet-module-posix-dev-r2.3'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
-        platforms: 'ruby'
-      - gem: 'puppet-module-win-dev-r2.1'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
-        platforms:
-          - 'mswin'
-          - 'mingw'
-          - 'x64_mingw'
-      - gem: 'puppet-module-win-dev-r2.3'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
+      - gem: 'puppet-module-win-dev-r#{minor_version}'
         platforms:
           - 'mswin'
           - 'mingw'
@@ -117,20 +95,9 @@ Gemfile:
         condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')"
     ':system_tests':
       # Gems built using puppet-module-gems utility
-      - gem: 'puppet-module-posix-system-r2.1'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
+      - gem: 'puppet-module-posix-system-r#{minor_version}'
         platforms: 'ruby'
-      - gem: 'puppet-module-posix-system-r2.3'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
-        platforms: 'ruby'
-      - gem: 'puppet-module-win-system-r2.1'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
-        platforms:
-          - 'mswin'
-          - 'mingw'
-          - 'x64_mingw'
-      - gem: 'puppet-module-win-system-r2.3'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
+      - gem: 'puppet-module-win-system-r#{minor_version}'
         platforms:
           - 'mswin'
           - 'mingw'

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -68,43 +68,43 @@
 Gemfile:
   required:
     ':development':
-      - gem: puppet-lint
-      # Only non-windows because it needs json
-      - gem: metadata-json-lint
+      # Gems built using puppet-module-gems utility
+      - gem: 'puppet-module-posix-default-r2.1'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
         platforms: 'ruby'
-      - gem: puppet_facts
-      # newer version required for ruby 1.9 compat
-      - gem: puppet-blacksmith
-        version: '>= 3.4.0'
-        platforms: 'ruby'
-      - gem: puppetlabs_spec_helper
-        version: '>= 1.2.1'
-      # newer version required to PUP-5743
-      - gem: rspec-puppet
-        version: '>= 2.3.2'
-      # Only non-windows because it needs json
-      - gem: rspec-puppet-facts
-        platforms: 'ruby'
-      # the newly released mocha 1.2.0 causes hangs during spec testing. See MODULES-3958 for a long-term solution
-      - gem: mocha
-        version: '< 1.2.0'
-      # Only non-windows because it needs json
-      - gem: simplecov
-        platforms: 'ruby'
-      - gem: parallel_tests
-        version: '< 2.10.0'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')"
-      - gem: parallel_tests
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')"
-      - gem: rubocop
-        version: '0.41.2'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')"
-      - gem: rubocop
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')"
-      - gem: rubocop-rspec
-        version: '~> 1.6'
+      - gem: 'puppet-module-posix-default-r2.3'
         condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
-      - gem: pry
+        platforms: 'ruby'
+      - gem: 'puppet-module-win-default-r2.1'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
+        platforms:
+          - 'mswin'
+          - 'mingw'
+          - 'x64_mingw'
+      - gem: 'puppet-module-win-default-r2.3'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
+        platforms:
+          - 'mswin'
+          - 'mingw'
+          - 'x64_mingw'
+      - gem: 'puppet-module-posix-dev-r2.1'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
+        platforms: 'ruby'
+      - gem: 'puppet-module-posix-dev-r2.3'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
+        platforms: 'ruby'
+      - gem: 'puppet-module-win-dev-r2.1'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
+        platforms:
+          - 'mswin'
+          - 'mingw'
+          - 'x64_mingw'
+      - gem: 'puppet-module-win-dev-r2.3'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
+        platforms:
+          - 'mswin'
+          - 'mingw'
+          - 'x64_mingw'
       # json_pure 2.0.2 added a requirement on ruby >= 2. We pin to json_pure <= 2.0.1
       # if using ruby 1.x
       - gem: json_pure
@@ -115,10 +115,26 @@ Gemfile:
         condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')"
       - gem: fast_gettext
         condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')"
-      # We don't want native extensions from rainbow
-      - gem: rainbow
-        version: '< 2.2.0'
     ':system_tests':
+      # Gems built using puppet-module-gems utility
+      - gem: 'puppet-module-posix-system-r2.1'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
+        platforms: 'ruby'
+      - gem: 'puppet-module-posix-system-r2.3'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
+        platforms: 'ruby'
+      - gem: 'puppet-module-win-system-r2.1'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.3.0')"
+        platforms:
+          - 'mswin'
+          - 'mingw'
+          - 'x64_mingw'
+      - gem: 'puppet-module-win-system-r2.3'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
+        platforms:
+          - 'mswin'
+          - 'mingw'
+          - 'x64_mingw'
       - gem: beaker
         version: '>= 3'
         from_env: 'BEAKER_VERSION'
@@ -126,9 +142,6 @@ Gemfile:
       - gem: beaker-pe
       - gem: beaker-rspec
         from_env: 'BEAKER_RSPEC_VERSION'
-      - gem: beaker-puppet_install_helper
-      - gem: beaker-module_install_helper
-      - gem: master_manipulator
       - gem: beaker-hostgenerator
         from_env: 'BEAKER_HOSTGENERATOR_VERSION'
       - gem: beaker-abs

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -92,7 +92,8 @@ group <%= group %> do
   ", :git => '#{gem['git']}'" if gem['git'] %><%=
   ", :branch => '#{gem['branch']}'" if gem['branch'] %><%=
   ", :ref => '#{gem['ref']}'" if gem['ref'] %><%=
-  ", :platforms => '#{gem['platforms']}'" if gem['platforms'] %><%=
+  ", :platforms => #{gem['platforms']}" if gem['platforms'].is_a?(Array) %><%=
+  ", :platforms => '#{gem['platforms']}'" if gem['platforms'] && !gem['platforms'].is_a?(Array) %><%=
   " if #{gem['condition']}" if gem['condition'] %>
 <% end -%>
 end

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -41,6 +41,8 @@ supports_windows = (
 -%>
 # Used for gem conditionals
 supports_windows = <%= supports_windows %>
+ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
+minor_version = "#{ruby_version_segments[0]}.#{ruby_version_segments[1]}"
 
 <% if supports_windows -%>
 # The following gems are not included by default as they require DevKit on Windows.
@@ -82,8 +84,8 @@ group <%= group %> do
 <%            gem['length'] -%>
 <%          end.max -%>
 <% gems.each do |gem| -%>
-  gem '<%=
-  gem['gem'] %>', <%
+  gem "<%=
+  gem['gem'] %>", <%
   if gem['from_env'] %>*location_for(ENV['<%= gem['from_env'] %>']<%= " || '#{gem['version']}'" if gem['version'] %>)<%
   else -%><%= "'#{gem['version']}', " if gem['version'] %><%
   end %><%=
@@ -93,7 +95,7 @@ group <%= group %> do
   ", :branch => '#{gem['branch']}'" if gem['branch'] %><%=
   ", :ref => '#{gem['ref']}'" if gem['ref'] %><%=
   ", :platforms => #{gem['platforms']}" if gem['platforms'].is_a?(Array) %><%=
-  ", :platforms => '#{gem['platforms']}'" if gem['platforms'] && !gem['platforms'].is_a?(Array) %><%=
+  ", :platforms => \"#{gem['platforms']}\"" if gem['platforms'] && !gem['platforms'].is_a?(Array) %><%=
   " if #{gem['condition']}" if gem['condition'] %>
 <% end -%>
 end


### PR DESCRIPTION
This involves removing a number of gems from the development and system_tests groups in the Gemfile config that have been abstracted out to puppet-module-gems and referencing just the puppet-module-gems themselves.

This is an attempt to reduce the need to run msync every time we have a dependency conflict, by simply updating the puppet-module-gems generated gems on rubygems to fix the dependency issues.