### PR TITLE
[MODULES-4528] Replace Puppet.version.to_f with versioncmp function

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 <% unless @configs['allow_deprecations'] -%>
-if Puppet.version.to_f >= 4.5
+if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   RSpec.configure do |c|
     c.before :each do
       Puppet.settings[:strict] = :error


### PR DESCRIPTION
With release of Puppet 4.10.0 using Puppet.version.to_f will return 4.1 which will cause issues with multiple test suites. This change uses Puppet's versioncmp function to do the comparison instead.