### PR TITLE
(maint) locales/config adjustments

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -180,4 +180,4 @@ locales/config.yaml:
   comments_tag: 'TRANSLATOR'
   bugs_address: 'docs@puppet.com'
   default_locale: 'en'
-  source_files: ['metadata.json']
+  source_files: []

--- a/moduleroot/locales/config.yaml
+++ b/moduleroot/locales/config.yaml
@@ -25,3 +25,4 @@ gettext:
   <% @configs['source_files'].each do |glob| -%>
     - '<%= glob -%>'
   <% end if @configs['source_files'].size > 0 -%>
+


### PR DESCRIPTION
metadata.json should not be in the source files array, as it is being managed separately now, which was my fault so this removes that and adds a newline to the end of the config.yaml template.