### PR TITLE
(MODULES-4511) add satellite_pe_tools to modulesync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: ruby
 rvm: 2.3.1
 cache: bundler
-# Run msync but in noop (Test Command).  Also, do not update the sqlserver/vsphere modules (regex escaped for yaml)
-script: 'bundle exec msync update --noop --git-base=https://github.com/ -x "(sqlserver|vsphere|yang_ietf)"'
+# Run msync but in noop (Test Command).  Also, do not update the private modules (regex escaped for yaml)
+script: 'bundle exec msync update --noop --git-base=https://github.com/ -x "(sqlserver|vsphere|yang_ietf|satellite_pe_tools)"'
 notifications:
   email: false

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -31,6 +31,7 @@
     puppetlabs-postgresql:               [linux]
     puppetlabs-puppet_agent:             [linux,windows]
     puppetlabs-rabbitmq:                 [linux]
+    puppetlabs-satellite_pe_tools:       [linux]
     puppetlabs-stdlib:                   [linux]
     puppetlabs-tagmail:                  [linux]
     puppetlabs-tftp:                     [linux]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -25,6 +25,7 @@
 - puppetlabs-rabbitmq
 - puppetlabs-reboot
 - puppetlabs-registry
+- puppetlabs-satellite_pe_tools
 - puppetlabs-sqlserver
 - puppetlabs-stdlib
 - puppetlabs-tagmail


### PR DESCRIPTION
we are welcoming the redhat satellite module into the modulesync family, yay. this adds it to both managed_modules and config_defaults (as a linux only module).