### PR TITLE
(maint) Add puppetlabs-windows to modsync

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -38,6 +38,7 @@
     puppetlabs-tomcat:                   [linux]
     puppetlabs-vcsrepo:                  [linux]
     puppetlabs-vsphere:                  [linux]
+    puppetlabs-windows:                  [windows]
     puppetlabs-xinetd:                   [linux]
     yang_ietf:                           [linux]
 

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -31,6 +31,7 @@
 - puppetlabs-tagmail
 - puppetlabs-tftp
 - puppetlabs-tomcat
+- puppetlabs-windows
 - puppetlabs-vcsrepo
 - puppetlabs-vsphere
 - puppetlabs-wsus_client


### PR DESCRIPTION
Previously the puppetlabs-windows module was not under modsync control.  This
commit adds the module so that module publishing can be automated.