### PR TITLE
(MODULES-5013) Update netscaler module with modsync

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -165,3 +165,11 @@ locales/config.yaml:
   bugs_address: 'docs@puppet.com'
   default_locale: 'en'
   source_files: []
+
+spec/spec_helper.rb:
+spec/acceptance/nodesets/centos-7-x64.yml:
+spec/acceptance/nodesets/debian-8-x64.yml:
+spec/acceptance/nodesets/default.yml:
+spec/acceptance/nodesets/docker/centos-7.yml:
+spec/acceptance/nodesets/docker/debian-8.yml:
+spec/acceptance/nodesets/docker/ubuntu-14.04.yml:

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -28,6 +28,7 @@
     puppetlabs-motd:                         [linux]
     puppetlabs-mysql:                        [linux]
     puppetlabs-ntp:                          [linux]
+    puppetlabs-netscaler:                    [linux]
     puppetlabs-postgresql:                   [linux]
     puppetlabs-puppet_agent:                 [linux,windows]
     puppetlabs-rabbitmq:                     [linux]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -18,6 +18,7 @@
 - puppetlabs-mongodb
 - puppetlabs-motd
 - puppetlabs-mysql
+- puppetlabs-netscaler
 - puppetlabs-ntp
 - puppetlabs-postgresql
 - puppetlabs-powershell


### PR DESCRIPTION
Previously the netscaler module was not modsync which is now causing CI failures
due to missing gems.  This commit will permanently add netscaler under modsync
control.