### PR TITLE
(MODULES-5139) bump travis matrix versions

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -64,10 +64,10 @@
     env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=@@SET@@
     script: bundle exec rake beaker
   includes:
-  - rvm: 2.3.1
-    env: PUPPET_GEM_VERSION="~> 4.0"
+  - rvm: 2.4.0
+    env: PUPPET_GEM_VERSION="~> 5.0"
     bundler_args: --without system_tests
-  - rvm: 2.1.7
+  - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.0"
     bundler_args: --without system_tests
 Gemfile:


### PR DESCRIPTION
Puppet platform 5.0.0 release is upon us so we need to update ruby and puppet versions in our travis configs. This adds a ruby 2.4.0/puppet 5 cell and updates ruby 2.1.7 to ruby 2.1.9 because that's the 2.1.x that the agent ships with.