### PR TITLE
(MODULES-5140) bump appveyor matrix versions

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -126,12 +126,12 @@ appveyor.yml:
       RUBY_VER: 21
     - PUPPET_GEM_VERSION: '~> 4.0'
       RUBY_VER: 21-x64
-    - PUPPET_GEM_VERSION: '~> 4.0'
-      RUBY_VER: 23
-    - PUPPET_GEM_VERSION: '~> 4.0'
-      RUBY_VER: 23-x64
+    - PUPPET_GEM_VERSION: '~> 5.0'
+      RUBY_VER: 24
+    - PUPPET_GEM_VERSION: '~> 5.0'
+      RUBY_VER: 24-x64
     # Oldest supported version
-    - PUPPET_GEM_VERSION: '4.2.3'
+    - PUPPET_GEM_VERSION: '4.7.1'
       RUBY_VER: 21-x64
   test_script:
   - "bundle exec rake spec SPEC_OPTS='--format documentation'"

--- a/moduleroot/appveyor.yml
+++ b/moduleroot/appveyor.yml
@@ -24,6 +24,18 @@ matrix:
   fast_finish: true
 install:
 - SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
+- ps: |
+    # AppVeyor appears to have OpenSSL headers available already
+    # which msys2 would normally install with:
+    # pacman -S mingw-w64-x86_64-openssl --noconfirm
+    #
+    if ( $(ruby --version) -match "^ruby\s+2\.4" ) {
+      Write-Output "Building OpenSSL gem ~> 2.0.4 to fix Ruby 2.4 / AppVeyor issue"
+      gem install openssl --version '~> 2.0.4' --no-ri --no-rdoc
+    }
+
+    gem list openssl
+    ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
 - <%= @configs['appveyor_bundle_install'] %>
 - type Gemfile.lock
 build: off


### PR DESCRIPTION
Puppet platform 5.0.0 release is upon us so we need to update ruby and puppet versions in our appveyor configs. This updates 23 and 23-x64 to 24 and 24-x64 as well as updating the oldest supported puppet version to 4.7.0