### PR TITLE
(MODULES-5291) Add github_changelog_generator gem

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -98,6 +98,9 @@ Gemfile:
         condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')"
       - gem: fast_gettext
         condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')"
+      - gem: 'github_changelog_generator'
+        git: 'https://github.com/DavidS/github-changelog-generator.git'
+        ref: 'adjust-tag-section-mapping'
     ':system_tests':
       # Gems built using puppet-module-gems utility
       - gem: 'puppet-module-posix-system-r#{minor_version}'


### PR DESCRIPTION
In order to start auto generating our changelogs we need all
modules to have the github_changelog_generator gem. Since we're
still waiting on a fix to be merged into the upstream version of the
gem, we're relying on David's fork which is being maintained with that
fix for the PDK.