### PR TITLE
(MODULES-5303) 0.0.7 pin puppet-module-win-dev-rXX

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -88,6 +88,7 @@ Gemfile:
           - 'mswin'
           - 'mingw'
           - 'x64_mingw'
+        version: '0.0.7'
       # json_pure 2.0.2 added a requirement on ruby >= 2. We pin to json_pure <= 2.0.1
       # if using ruby 1.x
       - gem: json_pure


### PR DESCRIPTION
 - Version 0.0.8 is causing problems inside Puppet Jenkins
   infrastructure due to the introduction of rspec-puppet-facts which
   depends transitively on json. Json is not satisfied with the gem
   included with Ruby, and thus attempts are made to compile native
   extensions where no compiler is available.

 - Version 0.0.9 and 0.0.10 include a newer version of
   metadata-json-lint (2.0.1) which depends on Puppet >= 4.7.0
   which hasn't yet been set to the minimum version across all
   pipeline definitions. For instance, Puppet is still running
   version 4.2.3 in some matrices.