### PR TITLE
(maint) Stop managing rabbitmq

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -31,7 +31,6 @@
     puppetlabs-netscaler:                    [linux]
     puppetlabs-postgresql:                   [linux]
     puppetlabs-puppet_agent:                 [linux,windows]
-    puppetlabs-rabbitmq:                     [linux]
     puppetlabs-satellite_pe_tools:           [linux]
     puppetlabs-stdlib:                       [linux]
     puppetlabs-tagmail:                      [linux]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -23,7 +23,6 @@
 - puppetlabs-postgresql
 - puppetlabs-powershell
 - puppetlabs-puppet_agent
-- puppetlabs-rabbitmq
 - puppetlabs-reboot
 - puppetlabs-registry
 - puppetlabs-satellite_pe_tools


### PR DESCRIPTION
We've given the rabbitmq to Vox Pupuli so we shouldn't manage it
with our modulesync configs anymore.