### PR TITLE
Revert "(MODULES-5291) Add github_changelog_generator gem"

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -98,9 +98,6 @@ Gemfile:
         condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')"
       - gem: fast_gettext
         condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')"
-      - gem: 'github_changelog_generator'
-        git: 'https://github.com/DavidS/github-changelog-generator.git'
-        ref: 'adjust-tag-section-mapping'
     ':system_tests':
       # Gems built using puppet-module-gems utility
       - gem: 'puppet-module-posix-system-r#{minor_version}'


### PR DESCRIPTION
This reverts commit c5ae7d0784a2718670521a2fc47de3b9a23afbc6.  This gem depends
on activesupport which requires Ruby 2.2 or above, which is incompatible with
Puppet testing which is on Ruby 2.1.9.