### PR TITLE
Use the correct ruby version (2.4.1) that corresponds with Puppet 5

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -63,7 +63,7 @@
     env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=@@SET@@
     script: bundle exec rake beaker
   includes:
-  - rvm: 2.4.0
+  - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 5.0"
     bundler_args: --without system_tests
   - rvm: 2.1.9


### PR DESCRIPTION
This patch aligns the version of ruby for testing Puppet 5 with the supported version.

https://docs.puppet.com/puppet/5.0/about_agent.html