### PR TITLE
(maint) adds contributing.md and updates source files for i18n

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -158,6 +158,8 @@ Rakefile:
   default_disabled_lint_checks:
   - 'relative'
 
+CONTRIBUTING.md:
+
 spec/spec.opts:
   delete: true
 
@@ -166,7 +168,8 @@ locales/config.yaml:
   comments_tag: 'TRANSLATOR'
   bugs_address: 'docs@puppet.com'
   default_locale: 'en'
-  source_files: []
+  source_files:
+    - './lib/**/*.rb'
 
 spec/spec_helper.rb:
 spec/acceptance/nodesets/centos-7-x64.yml:


### PR DESCRIPTION
This adds CONTRIBUTING.md to the config_defaults file so it is updated along with everything else. Also, since we're on the eve of releasing full i18n, I've updated the locales/config.yml with a generic 'source_files' glob.