### PR TITLE
(maint) - Adding java_ks to be managed as a Windows module

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -24,7 +24,7 @@
     puppetlabs-ibm_installation_manager:     [linux]
     puppetlabs-inifile:                      [linux]
     puppetlabs-java:                         [linux]
-    puppetlabs-java_ks:                      [linux]
+    puppetlabs-java_ks:                      [linux,windows]
     puppetlabs-mongodb:                      [linux]
     puppetlabs-motd:                         [linux,windows]
     puppetlabs-mysql:                        [linux]


### PR DESCRIPTION
Currently java-ks is only listed as a Linux module. It is actually
cross-platform therefore adding Windows to it. This will allow java_ks
to make use of files such as appveyor.yml