### PR TITLE
 (maint) - Removing mongodb

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -25,7 +25,6 @@
     puppetlabs-inifile:                      [linux]
     puppetlabs-java:                         [linux]
     puppetlabs-java_ks:                      [linux,windows]
-    puppetlabs-mongodb:                      [linux]
     puppetlabs-motd:                         [linux,windows]
     puppetlabs-mysql:                        [linux]
     puppetlabs-ntp:                          [linux]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -16,7 +16,6 @@
 - puppetlabs-inifile
 - puppetlabs-java
 - puppetlabs-java_ks
-- puppetlabs-mongodb
 - puppetlabs-motd
 - puppetlabs-mysql
 - puppetlabs-netscaler


### PR DESCRIPTION
Removing this module from our modulesync as it has been migrated to
voxpupuli.