### PR TITLE
(MODULES-6210) Add Variable to Contributing

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -160,6 +160,7 @@ Rakefile:
   - 'relative'
 
 CONTRIBUTING.md:
+  default_node_set: ./spec/acceptance/nodesets/default.yml  
 
 spec/spec.opts:
   delete: true

--- a/moduleroot/CONTRIBUTING.md.erb
+++ b/moduleroot/CONTRIBUTING.md.erb
@@ -190,7 +190,7 @@ Run the tests by issuing the following command
 % bundle exec rspec spec/acceptance
 ```
 
-This will now download a pre-fabricated image configured in the [default node-set](./spec/acceptance/nodesets/default.yml),
+This will now download a pre-fabricated image configured in the [default node-set](<%= @configs['default_node_set'] %>),
 install Puppet, copy this module, and install its dependencies per [spec/spec_helper_acceptance.rb](./spec/spec_helper_acceptance.rb)
 and then run all the tests under [spec/acceptance](./spec/acceptance).
 


### PR DESCRIPTION
Prior to this commit, all modules managed by modulesync share the
exact same file. However, each module can point to a different
default node set. Necessary changes to the puppetlabs-reboot
module (MODULES-5977) affect this line.

In order o make the necessary change to that module without
affecting any other modules _and_ to prevent the change from
being overwritten by modulesync, this commit adds a variable
interpolation for the default node set path.