### PR TITLE
MODULES-6103: Add `env` section to `.travis.yml` template

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,19 @@ extras: section with the same format to the module's .sync.yml.
 
 By setting the `docker_sets`, the .travis.yml file sets up full-system tests running in a docker container. `docker_defaults` allows you to specify or replace global defaults. Use the `options` entry on a docker set, to override individual options.
 
+You can add environment variable settings by adding an `env:` section to the
+module's `.sync.yml`.  The `env:` section may contain a `global:` section
+containing environment variables to be added to all builds, and/or a `matrix:`
+section, where each entry creates a new matrix entry to test.  For information,
+see https://docs.travis-ci.com/user/environment-variables/#Global-Variables .
+```
+.travis.yml:
+  env:
+    global:
+    # Reduce load on Travis servers to prevent tests from being killed
+    - PARALLEL_TEST_PROCESSORS=16
+```
+
 **`moduleroot/.rspec`**
 
 Flat file containing recommended default rspec options.

--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -7,6 +7,21 @@ script: <%= @configs['script'] %>
 #Inserting below due to the following issue: https://github.com/travis-ci/travis-ci/issues/3531#issuecomment-88311203
 before_install:
   - gem update bundler
+<% if @configs['env'] -%>
+env:
+<%   if @configs['env']['global'] -%>
+  global:
+<%     @configs['env']['global'].each do |env| -%>
+    - <%= env %>
+<%     end -%>
+<%   end -%>
+<%   if @configs['env']['matrix'] -%>
+  matrix:
+<%     @configs['env']['matrix'].each do |env| -%>
+    - <%= env %>
+<%     end -%>
+<%   end -%>
+<% end -%>
 matrix:
   fast_finish: true
   include:


### PR DESCRIPTION
Adds an option for an `env` section in the `.travis.yml` configuration,
to provide either `global` or `matrix` environment settings, per
https://docs.travis-ci.com/user/environment-variables/#Global-Variables