### PR TITLE
Remove motd from managed modules

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -16,7 +16,6 @@
 - puppetlabs-inifile
 - puppetlabs-java
 - puppetlabs-java_ks
-- puppetlabs-motd
 - puppetlabs-mysql
 - puppetlabs-netscaler
 - puppetlabs-ntp


### PR DESCRIPTION
Motd has been through a pdk convert - therefore removing it from modulesync.