### PR TITLE
(FM-6544) Add changelog generator

### DIFF
--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -8,6 +8,45 @@ PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('<%= check %>')
 <% end -%>
 
+<% if @configs['changelog_generator_since_tag'] -%>
+begin
+  require 'github_changelog_generator/task'
+  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+    config.future_release = YAML.load_file('metadata.json')['version']
+    config.since_tag = "<%= @configs['changelog_generator_since_tag'] %>"
+    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
+    config.add_pr_wo_labels = false
+    config.add_issues_wo_labels = false
+    config.configure_sections = {
+      "Changed" => {
+        "prefix" => "### Changed",
+        "labels" => ["backwards-incompatible"],
+      },
+      "Added" => {
+        "prefix" => "### Added",
+        "labels" => ["feature"],
+      },
+      "Fixed" => {
+        "prefix" => "### Fixed",
+        "labels" => ["bugfix"],
+      },
+    }
+    config.user = 'puppetlabs'
+    config.project = YAML.load_file('metadata.json')['name']
+  end
+rescue Errno::ENOENT
+  desc 'Could not find file metadata.json; cannot generate changelog'
+  task :changelog do
+    raise 'Could not find file metadata.json; cannot generate changelog'
+  end
+rescue LoadError
+  desc 'Install github_changelog_generator to get access to automatic changelog generation'
+  task :changelog do
+    raise 'Install github_changelog_generator to get access to automatic changelog generation'
+  end
+end
+
+<% end -%>
 desc 'Generate pooler nodesets'
 task :gen_nodeset do
   require 'beaker-hostgenerator'


### PR DESCRIPTION
This rake task will only be added if .sync.yml of target projects specifies a Rakefile entry called `changelog_generator_since_tag`