### PR TITLE
(maint) Remove AppVeyor OpenSSL update on Ruby 2.4

### DIFF
--- a/moduleroot/appveyor.yml.erb
+++ b/moduleroot/appveyor.yml.erb
@@ -25,15 +25,6 @@ matrix:
 install:
 - SET PATH=C:\Ruby%RUBY_VER%\bin;%PATH%
 - ps: |
-    # AppVeyor appears to have OpenSSL headers available already
-    # which msys2 would normally install with:
-    # pacman -S mingw-w64-x86_64-openssl --noconfirm
-    #
-    if ( $(ruby --version) -match "^ruby\s+2\.4" ) {
-      Write-Output "Building OpenSSL gem ~> 2.0.4 to fix Ruby 2.4 / AppVeyor issue"
-      gem install openssl --version '~> 2.0.4' --no-ri --no-rdoc
-    }
-
     gem list openssl
     ruby -ropenssl -e 'puts \"OpenSSL Version - #{OpenSSL::OPENSSL_VERSION}\"; puts \"OpenSSL Library Version - #{OpenSSL::OPENSSL_LIBRARY_VERSION}\"'
 - <%= @configs['appveyor_bundle_install'] %>


### PR DESCRIPTION
 - The fix in place here was temporary due to AppVeyor having available
   an older Ruby 2.4 that shipped a buggy OpenSSL with a race condition.
   Without the upgrade, installing large gemsets would intermittenly
   fail.

   * Original RubyInstaller discussion at:
   https://github.com/oneclick/rubyinstaller2/issues/68

   * Ruby bug is documented at https://bugs.ruby-lang.org/issues/11033

   * OpenSSL 2.0.4 contains the patch as of 8/8/2017
   https://github.com/ruby/ruby/commit/b08e0ade5baacbc7d4754e9f6afe8d09a3e00bc5#diff-51a5e2412fcf851e37d1883b1ae53de5

   * RubyInstaller 2.4.2-2 picked up the fix and was released 9/15/2017
   https://rubyinstaller.org/2017/09/15/rubyinstaller-2.4.2-2-released.html

   * AppVeyor issue was filed
   https://github.com/appveyor/ci/issues/1790

   AppVeyor began shipping updated Ruby in their 11/18/2017 release:
   https://github.com/appveyor/ci/issues/1892
   https://www.appveyor.com/updates/