### PR TITLE
(MODULES-6339) Remove bundler update from before_install

### DIFF
--- a/moduleroot/.travis.yml.erb
+++ b/moduleroot/.travis.yml.erb
@@ -4,9 +4,6 @@ sudo: false
 language: ruby
 cache: bundler
 script: <%= @configs['script'] %>
-#Inserting below due to the following issue: https://github.com/travis-ci/travis-ci/issues/3531#issuecomment-88311203
-before_install:
-  - gem update bundler
 <% if @configs['env'] -%>
 env:
 <%   if @configs['env']['global'] -%>


### PR DESCRIPTION
Prior to this commit the travis.yml template includes a before_install
step which upgrades bundler. This was done to solve for an issue where
Travis included the default version of bundler for each ruby version
in the matrix. Now, however, Travis seems to include the latest
compatible version of bundler - at this time, `1.16.0` - and we are
upgrading to `1.16.1` which has an incompatibility issue on Travis
at this time.

This commit removes the now-unneccessary update step and puts the
heavy lifting for maintaining a compatible matrix back onto Travis.

A downside to this is that we may have future breaks caused by Travis
mismanaging their images, but this is a risk we already have. An
alternative is to pin to a version ourselves and manage the pinned
version over time.