### PR TITLE
(maint) Add mount_iso unsupported module

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -26,6 +26,7 @@
     puppetlabs-inifile:                      [linux]
     puppetlabs-java:                         [linux]
     puppetlabs-java_ks:                      [linux,windows]
+    puppetlabs-mount_iso:                    [windows]
     puppetlabs-mysql:                        [linux]
     puppetlabs-ntp:                          [linux]
     puppetlabs-netscaler:                    [linux]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -16,6 +16,7 @@
 - puppetlabs-inifile
 - puppetlabs-java
 - puppetlabs-java_ks
+- puppetlabs-mount_iso
 - puppetlabs-mysql
 - puppetlabs-netscaler
 - puppetlabs-ntp


### PR DESCRIPTION
This commit adds the unsupported mount_iso module to be under modsync control.