### PR TITLE
(MODULES-6325) - Removal of vcsrepo

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -42,7 +42,6 @@
     puppetlabs-tftp:                         [linux]
     puppetlabs-tomcat:                       [linux]
     puppetlabs-translate:                    [linux]
-    puppetlabs-vcsrepo:                      [linux]
     puppetlabs-vsphere:                      [linux]
     puppetlabs-websphere_application_server: [linux]
     puppetlabs-windows:                      [windows]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -40,7 +40,6 @@
 - puppetlabs-tftp
 - puppetlabs-tomcat
 - puppetlabs-translate
-- puppetlabs-vcsrepo
 - puppetlabs-vsphere
 - puppetlabs-websphere_application_server
 - puppetlabs-windows


### PR DESCRIPTION
This is being removed from modulesync because it has been converted to
be PDK compliant. Changes will now be managed using pdk-templates.