### PR TITLE
(MODULES-6328) - Removing accounts due to PDK convert

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,7 +1,6 @@
 ---
 :global:
   supported_oss:
-    puppetlabs-accounts:                     [linux]
     puppetlabs-acl:                          [windows]
     puppetlabs-apache:                       [linux]
     puppetlabs-apt:                          [linux]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -1,5 +1,4 @@
 ---
-- puppetlabs-accounts
 - puppetlabs-acl
 - puppetlabs-apache
 - puppetlabs-apt


### PR DESCRIPTION
This is being removed from modulesync because it has been converted to
be PDK compliant. Changes will now be managed using pdk-templates.