### PR TITLE
(MODULES-6452) - Remove apt from modulesync

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -3,7 +3,6 @@
   supported_oss:
     puppetlabs-acl:                          [windows]
     puppetlabs-apache:                       [linux]
-    puppetlabs-apt:                          [linux]
     puppetlabs-bootstrap:                    [linux,windows]
     puppetlabs-chocolatey:                   [windows]
     puppetlabs-concat:                       [linux,windows]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -1,7 +1,6 @@
 ---
 - puppetlabs-acl
 - puppetlabs-apache
-- puppetlabs-apt
 - puppetlabs-bootstrap
 - puppetlabs-chocolatey
 - puppetlabs-concat


### PR DESCRIPTION
apt is being removed as it will recieve updates from pdk templates.