### PR TITLE
(MODULES-6457)- Remove haproxy from modulesync

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -12,7 +12,6 @@
     puppetlabs-exec:                         [linux,windows]
     puppetlabs-facter_task:                  [linux,windows]
     puppetlabs-firewall:                     [linux]
-    puppetlabs-haproxy:                      [linux]
     puppetlabs-hocon:                        [linux]
     puppetlabs-ibm_installation_manager:     [linux]
     puppetlabs-iis:                          [windows]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -10,7 +10,6 @@
 - puppetlabs-exec
 - puppetlabs-facter_task
 - puppetlabs-firewall
-- puppetlabs-haproxy
 - puppetlabs-hocon
 - puppetlabs-ibm_installation_manager
 - puppetlabs-iis


### PR DESCRIPTION
This module is now compliant with the pdk. Updates will be pushed out via templates.