### PR TITLE
(MODULES-6455) - Removing firewall from modulesync

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -11,7 +11,6 @@
     puppetlabs-dsc_lite:                     [windows]
     puppetlabs-exec:                         [linux,windows]
     puppetlabs-facter_task:                  [linux,windows]
-    puppetlabs-firewall:                     [linux]
     puppetlabs-hocon:                        [linux]
     puppetlabs-ibm_installation_manager:     [linux]
     puppetlabs-iis:                          [windows]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -9,7 +9,6 @@
 - puppetlabs-dsc_lite
 - puppetlabs-exec
 - puppetlabs-facter_task
-- puppetlabs-firewall
 - puppetlabs-hocon
 - puppetlabs-ibm_installation_manager
 - puppetlabs-iis


### PR DESCRIPTION
This module has now been converted and is PDK compliant. Any required changes will be pushed out via the pdk templates.