### PR TITLE
(MODULES-6462) - Removing exec from modulesync

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -9,7 +9,6 @@
     puppetlabs-dism:                         [windows]
     puppetlabs-dsc:                          [windows]
     puppetlabs-dsc_lite:                     [windows]
-    puppetlabs-exec:                         [linux,windows]
     puppetlabs-facter_task:                  [linux,windows]
     puppetlabs-hocon:                        [linux]
     puppetlabs-ibm_installation_manager:     [linux]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -7,7 +7,6 @@
 - puppetlabs-dism
 - puppetlabs-dsc
 - puppetlabs-dsc_lite
-- puppetlabs-exec
 - puppetlabs-facter_task
 - puppetlabs-hocon
 - puppetlabs-ibm_installation_manager


### PR DESCRIPTION
This module has been converted and is now PDK compliant therefore is no longer needed in modulesync.