### PR TITLE
(maint) Remove PDK managed scheduled_task module

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -26,7 +26,6 @@
     puppetlabs-registry:                     [windows]
     puppetlabs-resource:                     [linux,windows]
     puppetlabs-satellite_pe_tools:           [linux]
-    puppetlabs-scheduled_task:               [windows]
     puppetlabs-service:                      [linux,windows]
     puppetlabs-sqlserver:                    [windows]
     puppetlabs-stdlib:                       [linux,windows]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -24,7 +24,6 @@
 - puppetlabs-resource
 - puppetlabs-registry
 - puppetlabs-satellite_pe_tools
-- puppetlabs-scheduled_task
 - puppetlabs-service
 - puppetlabs-sqlserver
 - puppetlabs-stdlib


### PR DESCRIPTION
 - Undoes changes from f56e5875e1f308db10f623a5704c52e56c09cc68 as
   puppetlabs-scheduled_task is a PDK module and should not be managed
   with modulesync any longer.

 - See https://github.com/puppetlabs/puppetlabs-scheduled_task/pull/14
       https://tickets.puppetlabs.com/browse/MODULES-6591