### PR TITLE
(MODULES-6454) - Removing mysql from modulesync

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -15,7 +15,6 @@
     puppetlabs-iis:                          [windows]
     puppetlabs-java_ks:                      [linux,windows]
     puppetlabs-mount_iso:                    [windows]
-    puppetlabs-mysql:                        [linux]
     puppetlabs-netscaler:                    [linux]
     puppetlabs-package:                      [linux,windows]
     puppetlabs-postgresql:                   [linux]

--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -13,7 +13,6 @@
 - puppetlabs-iis
 - puppetlabs-java_ks
 - puppetlabs-mount_iso
-- puppetlabs-mysql
 - puppetlabs-netscaler
 - puppetlabs-package
 - puppetlabs-postgresql


### PR DESCRIPTION
This module has been converted and is now PDK compliant therefore is no longer needed in modulesync.