### PR TITLE
Revert "(FM-6544) More changes for #174"

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -82,9 +82,6 @@ Gemfile:
         condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')"
       - gem: fast_gettext
         condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')"
-      - gem: 'github_changelog_generator'
-        from_env: 'GITHUB_CHANGELOG_GENERATOR_VERSION'
-        version: 'git@github.com:skywinder/github-changelog-generator#master'
     ':system_tests':
       # Gems built using puppet-module-gems utility
       - gem: 'puppet-module-posix-system-r#{minor_version}'

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -15,16 +15,8 @@ begin
     config.future_release = YAML.load_file('metadata.json')['version']
     config.since_tag = "<%= @configs['changelog_generator_since_tag'] %>"
     config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
-    # All PRs should be labeled.
-    config.add_pr_wo_labels = true
-    # We don't deal with issues, just PRs.
-    config.issues = false
-    # "maintenance" label is excluded from changelog.
-    config.exclude_labels = ["maintenance"]
-    # Make it obvious what prep work remains.
-    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
-    # Configure standard sections as per http://keepachangelog.com/ but without
-    # security/deprecated/removed sections as they do not conform to SemVer.
+    config.add_pr_wo_labels = false
+    config.add_issues_wo_labels = false
     config.configure_sections = {
       "Changed" => {
         "prefix" => "### Changed",


### PR DESCRIPTION
This reverts commit ffe29d9c9809cb4427f6b0e87ad699736fed5119.

The git reference assumes a configured SSH agent for the git client.  This is a
new requirement for module development and breaks the more usual Windows
development workflows which do not depend on an SSH agent.  Also this will break
bundling on default configured git clients which only need read only access to
repositories, for example CI testing in Jenkins, Appveyor, Travis and the like.