### PR TITLE
(maint) Remove reboot module

### DIFF
--- a/managed_modules.yml
+++ b/managed_modules.yml
@@ -4,7 +4,6 @@
 - puppetlabs-mount_iso
 - puppetlabs-netscaler
 - puppetlabs-puppet_agent
-- puppetlabs-reboot
 - puppetlabs-satellite_pe_tools
 - puppetlabs-tftp
 - puppetlabs-translate


### PR DESCRIPTION
This commit removes the reboot module as it has been converted to PDK.